### PR TITLE
Add GET, POST, PUT endpoints for products with DTOs and FK error handling

### DIFF
--- a/CornerStore/CornerStore.csproj
+++ b/CornerStore/CornerStore.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>19fe3540-b6f8-40ff-851c-09d66e0482ff</UserSecretsId>
   </PropertyGroup>

--- a/CornerStore/Program.cs
+++ b/CornerStore/Program.cs
@@ -1,5 +1,7 @@
+using Npgsql;
 using CornerStore;
 using CornerStore.Models;
+using CornerStore.DTOs;
 using Microsoft.EntityFrameworkCore;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http.Json;
@@ -34,7 +36,103 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-//endpoints go here
+// ! Endpoints
+
+// Endpoint: GET /products
+app.MapGet("/products", async (CornerStoreDbContext db) =>
+{
+    try
+    {
+        List<ProductDetailDTO> products = await db.Products
+            .Include(p => p.Category)
+            .Select(p => new ProductDetailDTO
+            {
+                Id = p.Id,
+                ProductName = p.ProductName,
+                Price = p.Price,
+                Brand = p.Brand,
+                CategoryName = p.Category.CategoryName
+            })
+            .ToListAsync();
+
+        return Results.Ok(products);
+    }
+    catch (Exception)
+    {
+        return Results.Problem("Unable to retrieve products. Please try again later.");
+    }
+});
+
+// Endpoint: POST /products
+app.MapPost("/products", async (ProductCreateDTO dto, CornerStoreDbContext db) =>
+{
+    try
+    {
+        Product product = new Product
+        {
+            ProductName = dto.ProductName,
+            Price = dto.Price,
+            Brand = dto.Brand,
+            CategoryId = dto.CategoryId
+        };
+
+        db.Products.Add(product);
+        await db.SaveChangesAsync();
+
+        ProductDTO result = new ProductDTO
+        {
+            Id = product.Id,
+            ProductName = product.ProductName,
+            Price = product.Price,
+            Brand = product.Brand,
+            CategoryId = product.CategoryId
+        };
+
+        return Results.Created($"/products/{product.Id}", result);
+    }
+    // Catches foreign key violations — e.g., when the provided CategoryId doesn't exist.
+    catch (DbUpdateException ex) when (ex.InnerException is PostgresException pg && pg.SqlState == "23503")
+    {
+        return Results.BadRequest("Invalid categoryId: foreign key constraint violated.");
+    }
+});
+
+// Endpoint: PUT /products
+app.MapPut("/products/{id}", async (int id, ProductCreateDTO dto, CornerStoreDbContext db) =>
+{
+    try
+    {
+        Product? product = await db.Products.FindAsync(id);
+        if (product == null)
+        {
+            return Results.NotFound($"No product found with ID {id}.");
+        }
+
+        product.ProductName = dto.ProductName;
+        product.Price = dto.Price;
+        product.Brand = dto.Brand;
+        product.CategoryId = dto.CategoryId;
+
+        await db.SaveChangesAsync();
+
+        ProductDTO result = new ProductDTO
+        {
+            Id = product.Id,
+            ProductName = product.ProductName,
+            Price = product.Price,
+            Brand = product.Brand,
+            CategoryId = product.CategoryId
+        };
+
+        return Results.Ok(result);
+    }
+    // Handles FK constraint violation if CategoryId is invalid
+    catch (DbUpdateException ex) when (ex.InnerException is PostgresException pg && pg.SqlState == "23503")
+    {
+        return Results.BadRequest("Invalid categoryId: foreign key constraint violated.");
+    }
+});
+
 
 app.Run();
 


### PR DESCRIPTION
##  Feature: Product Endpoints (GET, POST, PUT)

### Summary
Implements core product endpoints using DTOs and includes basic error handling:

- `GET /products` → returns list of `ProductDetailDTO`
- `POST /products` → accepts `ProductCreateDTO`, returns `ProductDTO`
- `PUT /products/{id}` → updates existing product, returns `ProductDTO`

### Notes
- Catches `PostgresException` for FK violations (`SQLSTATE 23503`)
- Returns `404` on missing products for update
- Nullable context enabled in `.csproj`
- Swagger tested locally

