### PR TITLE
Add GET and DELETE /orders endpoints with optional orderDate filtering

### DIFF
--- a/CornerStore/DTOs/OrderCreateDTO.cs
+++ b/CornerStore/DTOs/OrderCreateDTO.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace CornerStore.DTOs;
+
+public class OrderCreateDTO
+{
+    public int CashierId { get; set; }
+    public List<OrderProductCreateDTO> Products { get; set; } = new();
+}

--- a/CornerStore/DTOs/OrderProductCreateDTO.cs
+++ b/CornerStore/DTOs/OrderProductCreateDTO.cs
@@ -1,0 +1,7 @@
+namespace CornerStore.DTOs;
+
+public class OrderProductCreateDTO
+{
+    public int ProductId { get; set; }
+    public int Quantity { get; set; }
+}


### PR DESCRIPTION
##  Feature: POST, GET and DELETE Orders Endpoints

### Summary
Implements remaining functionality for the `/orders` resource.

### Endpoints
- `POST /orders` — Allows the posting of an order
- `GET /orders` — Returns all orders, with optional `orderDate=YYYY-MM-DD` filter
- `DELETE /orders/{id}` — Deletes an order by ID

### Details
- Filters `PaidOnDate` by `.Date` match (time ignored)
- Includes full `OrderDTO` shape: cashier name, order total, nested product list
- Graceful fallback for invalid IDs (`404 Not Found`)
- Returns `204 No Content` on successful delete

### Next Steps
- `/products/popular` challenge endpoint (optional)
