### PR TITLE
fix: silence nullable navigation property warnings in EF models and endpoints

### DIFF
--- a/CornerStore/Models/Order.cs
+++ b/CornerStore/Models/Order.cs
@@ -12,7 +12,7 @@ public class Order
     public int CashierId { get; set; }
 
     [Required]
-    public Cashier Cashier { get; set; }
+    public Cashier? Cashier { get; set; }
 
     public DateTime? PaidOnDate { get; set; }
 
@@ -20,5 +20,5 @@ public class Order
     public List<OrderProduct> OrderProducts { get; set; } = new();
 
     [NotMapped]
-    public decimal Total => OrderProducts.Sum(op => op.Product.Price * op.Quantity);
+    public decimal Total => OrderProducts.Sum(op => op.Product!.Price * op.Quantity);
 }

--- a/CornerStore/Models/OrderProduct.cs
+++ b/CornerStore/Models/OrderProduct.cs
@@ -9,13 +9,13 @@ public class OrderProduct
     public int OrderId { get; set; }
 
     [Required]
-    public Order Order { get; set; }
+    public Order? Order { get; set; }
 
     [Required]
     public int ProductId { get; set; }
 
     [Required]
-    public Product Product { get; set; }
+    public Product? Product { get; set; }
 
     [Required]
     public int Quantity { get; set; }

--- a/CornerStore/Models/Product.cs
+++ b/CornerStore/Models/Product.cs
@@ -20,7 +20,7 @@ public class Product
     [Required]
     public int CategoryId { get; set; }
 
-    public Category Category { get; set; }
+    public Category? Category { get; set; }
 
     public List<OrderProduct> OrderProducts { get; set; } = new();
 }

--- a/CornerStore/Program.cs
+++ b/CornerStore/Program.cs
@@ -51,7 +51,7 @@ app.MapGet("/products", async (CornerStoreDbContext db) =>
                 ProductName = p.ProductName,
                 Price = p.Price,
                 Brand = p.Brand,
-                CategoryName = p.Category.CategoryName
+                CategoryName = p.Category!.CategoryName
             })
             .ToListAsync();
 
@@ -180,7 +180,7 @@ app.MapGet("/cashiers/{id}", async (int id, CornerStoreDbContext db) =>
         Products = order.OrderProducts.Select(op => new OrderProductDTO
         {
             ProductId = op.ProductId,
-            ProductName = op.Product.ProductName,
+            ProductName = op.Product!.ProductName,
             Quantity = op.Quantity,
             Price = op.Product.Price
         }).ToList()
@@ -284,13 +284,13 @@ app.MapGet("/orders", async (string? orderDate, CornerStoreDbContext db) =>
     {
         Id = order.Id,
         CashierId = order.CashierId,
-        CashierFullName = $"{order.Cashier.FirstName} {order.Cashier.LastName}",
+        CashierFullName = $"{order.Cashier!.FirstName} {order.Cashier.LastName}",
         PaidOnDate = order.PaidOnDate,
         Total = order.Total,
         Products = order.OrderProducts.Select(op => new OrderProductDTO
         {
             ProductId = op.ProductId,
-            ProductName = op.Product.ProductName,
+            ProductName = op.Product!.ProductName,
             Quantity = op.Quantity,
             Price = op.Product.Price
         }).ToList()


### PR DESCRIPTION
# Fix nullable reference warnings for EF Core navigation properties

## What’s fixed

- Marked EF Core navigation properties (`Cashier`, `Product`, `Order`) as nullable to resolve CS8618 warnings.
- Used null-forgiving operator (`!`) in computed properties and API projections to silence CS8602 warnings where navigation properties are known to be loaded via `.Include()`.
- Ensured runtime behavior remains unchanged — models are EF-compliant, and Swagger confirms all endpoints function correctly.

